### PR TITLE
4 add automatic rating assigning to users on first fetch if not present

### DIFF
--- a/Src/Bot/Cogs/RatingCommands.py
+++ b/Src/Bot/Cogs/RatingCommands.py
@@ -29,6 +29,18 @@ class RatingCommands(commands.Cog):
     @commands.guild_only()
     @PermissionsCheck(PermissionLevel.admin)
     async def rating(self, ctx: ScrimContext, user: User, game: Game, rating: RatingConverter):
+        """
+        A command that sets the given user's rating for the given game as the given value. Only usable by admins
+
+        :param ctx: The invocation context of the command
+        :type ctx: ScrimContext
+        :param user: The user whose rating is being set
+        :type user: User
+        :param game: The game of which rating is being set for the given user
+        :type game: Game
+        :param rating: The rating value the user's rating for the game will be set as
+        :type rating: RatingConverter
+        """
         guild = self._guild_converter.get_guild(ctx.guild.id)
         new_rating = self._rating_converter.create_user_rating(rating, user, game, guild)
         await self._embed_builder.send(ctx, displayable=new_rating)
@@ -36,6 +48,16 @@ class RatingCommands(commands.Cog):
     @commands.command(aliases=["stats"])
     @commands.guild_only()
     async def statistics(self, ctx: ScrimContext, user: User, game: Game):
+        """
+        A command that displays given user's statistics for the given game
+
+        :param ctx: The invocation context of the command
+        :type ctx: ScrimContext
+        :param user: The user whose statistics are being requested
+        :type user: User
+        :param game: The game of which statistics for the given user are being requested
+        :type game: Game
+        """
         guild = self._guild_converter.get_guild(ctx.guild.id)
         new_rating = self._rating_converter.get_user_statistics(user, game, guild)
         await self._embed_builder.send(ctx, displayable=new_rating)

--- a/Src/Bot/Cogs/RatingCommands.py
+++ b/Src/Bot/Cogs/RatingCommands.py
@@ -33,6 +33,13 @@ class RatingCommands(commands.Cog):
         new_rating = self._rating_converter.create_user_rating(rating, user, game, guild)
         await self._embed_builder.send(ctx, displayable=new_rating)
 
+    @commands.command(aliases=["stats"])
+    @commands.guild_only()
+    async def statistics(self, ctx: ScrimContext, user: User, game: Game):
+        guild = self._guild_converter.get_guild(ctx.guild.id)
+        new_rating = self._rating_converter.get_user_statistics(user, game, guild)
+        await self._embed_builder.send(ctx, displayable=new_rating)
+
 
 def setup(client: ScrimBotClient):
     client.add_cog(RatingCommands())

--- a/Src/Bot/DataClasses/Scrim.py
+++ b/Src/Bot/DataClasses/Scrim.py
@@ -24,3 +24,4 @@ class Scrim(DataClass):  # pragma: no cover
     game = relationship("Game", back_populates="scrims")
     scrim_channel = relationship("ScrimChannel", back_populates="scrims")
     teams = relationship("ParticipantTeam", back_populates="scrim")
+    results = relationship("UserScrimResult", back_populates="scrim")

--- a/Src/Bot/DataClasses/UserScrimResult.py
+++ b/Src/Bot/DataClasses/UserScrimResult.py
@@ -17,13 +17,14 @@ class Result(enum.Enum):
 
 
 class UserScrimResult(DataClass):  # pragma: no cover
-    rating_id = Column(Integer, ForeignKey("UserRatings.rating_id"), primary_key=True)
     user_id = Column(Integer, ForeignKey("Users.user_id"), primary_key=True)
     scrim_id = Column(Integer, ForeignKey("Scrims.scrim_id"), primary_key=True)
+    rating_id = Column(Integer, ForeignKey("UserRatings.rating_id"), default=None)
     frozen_rating = Column(Integer, nullable=False)
     result = Column(Enum(Result), default=Result.UNREGISTERED)
 
     rating = relationship("UserRating", back_populates="results")
+    scrim = relationship("Scrim", back_populates="results")
 
     def __init__(self, rating_id: int, user_id: int, scrim_id: int, frozen_rating: int,
                  result: Result = Result.UNREGISTERED):

--- a/Src/Database/DatabaseConnections/UserRatingConnection.py
+++ b/Src/Database/DatabaseConnections/UserRatingConnection.py
@@ -55,7 +55,17 @@ class UserRatingConnection(ConnectionBase):
         new_rating.user = user
         new_rating.game = game
         new_rating.guild = guild
+        new_rating.results = []
         with self._master_connection.get_session() as session:
             session.add(new_rating)
+        self._bind_results(new_rating)
         return new_rating
+
+    def _bind_results(self, new_rating: UserRating):
+        with self._master_connection.get_session() as session:
+            query = session.query(UserScrimResult).outerjoin(UserScrimResult.scrim)\
+                .filter(Scrim.game_name == new_rating.game.name)\
+                .filter(UserScrimResult.user_id == new_rating.user_id)
+            for result in query.all():
+                new_rating.results.append(result)
 

--- a/Test/AcceptanceTest/Ratings.feature
+++ b/Test/AcceptanceTest/Ratings.feature
@@ -98,7 +98,7 @@ Feature: Setting, updating and displaying user ratings for games on both guild a
     Could not convert argument 'invalid' into type Game because argument did not correspond to any name or alias for a registered game
     """
 
-  Scenario: Displaying statistics for uninitialized user
+  Scenario: Displaying statistics for an uninitialized user
     When ;statistics {user_id} dota is called
     Then embed received with fields
       | name              | value                             |

--- a/Test/AcceptanceTest/Ratings.feature
+++ b/Test/AcceptanceTest/Ratings.feature
@@ -97,3 +97,36 @@ Feature: Setting, updating and displaying user ratings for games on both guild a
     """
     Could not convert argument 'invalid' into type Game because argument did not correspond to any name or alias for a registered game
     """
+
+  Scenario: Displaying statistics for uninitialized user
+    When ;statistics {user_id} dota is called
+    Then embed received with fields
+      | name              | value                             |
+      | Author            | Dota 2                            |
+      | Icon              | https://i.imgur.com/OlWIlyY.jpg?1 |
+      | Colour            | 0xce0000                          |
+      | Player statistics | <@!{user_id}>                     |
+      | Thumbnail         | {user_id}.icon                    |
+      | Games played      | 0                                 |
+      | Wins              | 0                                 |
+      | Losses            | 0                                 |
+      | Ties              | 0                                 |
+      | Unrecorded        | 0                                 |
+      | Rating            | 1700                              |
+
+  Scenario: Displaying statistics for an initialized user
+    Given user {user_id} has a dota rating of 400
+    When ;statistics {user_id} dota is called
+    Then embed received with fields
+      | name              | value                             |
+      | Author            | Dota 2                            |
+      | Icon              | https://i.imgur.com/OlWIlyY.jpg?1 |
+      | Colour            | 0xce0000                          |
+      | Player statistics | <@!{user_id}>                     |
+      | Thumbnail         | {user_id}.icon                    |
+      | Games played      | 0                                 |
+      | Wins              | 0                                 |
+      | Losses            | 0                                 |
+      | Ties              | 0                                 |
+      | Unrecorded        | 0                                 |
+      | Rating            | 400                               |

--- a/Test/AcceptanceTest/environment.py
+++ b/Test/AcceptanceTest/environment.py
@@ -14,6 +14,7 @@ from Test.Utils.TestHelpers.ResponseLoggerContext import ResponseLoggerContext
 from Test.Utils.TestHelpers.ResponseMessageCatcher import ResponseMessageCatcher
 from Test.Utils.TestHelpers.UserFetchPatcher import UserFetchPatcher
 from Test.Utils.TestHelpers.MockMemberConverter import MockMemberConverter
+from Utils.TestHelpers.TestIdGenerator import GLOBAL_ID_GENERATOR
 
 
 def before_feature(context, feature):
@@ -25,7 +26,8 @@ def before_feature(context, feature):
 
 
 def before_scenario(context, scenario):
-    context.discord_ids = {"divider": "----------------------------------------------"}
+    context.discord_ids = {"divider": "----------------------------------------------",
+                           "user_id": GLOBAL_ID_GENERATOR.generate_viable_id()}
     context.command_messages = []
     context.mocked_users = {}
     context.patcher = DiscordPatcher()

--- a/Test/AcceptanceTest/environment.py
+++ b/Test/AcceptanceTest/environment.py
@@ -14,7 +14,7 @@ from Test.Utils.TestHelpers.ResponseLoggerContext import ResponseLoggerContext
 from Test.Utils.TestHelpers.ResponseMessageCatcher import ResponseMessageCatcher
 from Test.Utils.TestHelpers.UserFetchPatcher import UserFetchPatcher
 from Test.Utils.TestHelpers.MockMemberConverter import MockMemberConverter
-from Utils.TestHelpers.TestIdGenerator import GLOBAL_ID_GENERATOR
+from Test.Utils.TestHelpers.TestIdGenerator import GLOBAL_ID_GENERATOR
 
 
 def before_feature(context, feature):

--- a/Test/AcceptanceTest/steps/mock_discord_objects_steps.py
+++ b/Test/AcceptanceTest/steps/mock_discord_objects_steps.py
@@ -12,7 +12,7 @@ from behave.runner import Context
 
 from Test.Utils.TestHelpers.MockDiscordConverter import MockDiscordConverter
 from Test.Utils.TestHelpers.TestIdGenerator import GLOBAL_ID_GENERATOR
-from Test.Utils.TestHelpers.id_parser import get_id_increment, try_get_id, parse_player_spec
+from Test.Utils.TestHelpers.id_parser import get_id_increment, try_get_id, parse_player_spec, process_inserts
 from Test.Utils.TestHelpers.test_utils import create_mock_channel, create_mock_guild, create_mock_channel_group, \
     set_member_voice_present, set_member_voice_not_present, create_mock_author
 from Test.Utils.TestHelpers.VoiceChannelFetchPatcher import VoiceChannelFetchPatcher

--- a/Test/UnitTest/Bot/Cogs/TestRatingCommands.py
+++ b/Test/UnitTest/Bot/Cogs/TestRatingCommands.py
@@ -31,3 +31,16 @@ class TestRatingCommands(AsyncUnittestBase):
         self.mock_guild_converter.get_guild.assert_called_with(mock_context.guild.id)
         self.mock_user_rating_converter.create_user_rating.assert_called_with(rating, mock_user, mock_game, mock_guild)
         self.mock_embed_builder.send.assert_called_with(mock_context, displayable=mock_rating)
+
+    async def test_statistics_when_given_user_and_game_then_stats_fetched_and_displayed(self):
+        mock_user = MagicMock()
+        mock_game = MagicMock()
+        mock_context = MagicMock()
+        mock_rating = MagicMock()
+        mock_guild = MagicMock()
+        self.mock_guild_converter.get_guild.return_value = mock_guild
+        self.mock_user_rating_converter.get_user_statistics.return_value = mock_rating
+        await self.cog.statistics(mock_context, mock_user, mock_game)
+        self.mock_guild_converter.get_guild.assert_called_with(mock_context.guild.id)
+        self.mock_user_rating_converter.get_user_statistics.assert_called_with(mock_user, mock_game, mock_guild)
+        self.mock_embed_builder.send.assert_called_with(mock_context, displayable=mock_rating)

--- a/Test/UnitTest/Database/DatabaseConnections/TestUserRatingConnection.py
+++ b/Test/UnitTest/Database/DatabaseConnections/TestUserRatingConnection.py
@@ -89,6 +89,19 @@ class TestUserRatingConnection(UnittestBase):
         expected_user_rating.rating = 4424
         self._assert_equal_ratings(expected_user_rating, actual_user_rating)
 
+    def test_rating_given_existing_results_when_new_rating_created_then_results_linked(self):
+        expected_user_rating = MagicMock()
+        expected_user_rating.game = self._create_game()
+        expected_user_rating.user = self._create_user()
+        expected_user_rating.guild = self._create_guild()
+        expected_user_rating.rating_id = None
+        results = _create_result_list(12, 7)
+        self._create_results(expected_user_rating, *results)
+        actual_user_rating = self.connection.get_user_rating(expected_user_rating.user, expected_user_rating.game,
+                                                             expected_user_rating.guild)
+        self.assertEqual(expected_user_rating.game.name, actual_user_rating.game.name)
+        self._assert_results(actual_user_rating, 12, 7)
+
     def _assert_results(self, rating: UserRating, expected_wins: int, expected_losses: int, expected_ties: int = 0,
                         expected_unregistered: int = 0):
         wins = len(list(filter(lambda x: x.result == Result.WIN, rating.results)))

--- a/Test/Utils/TestHelpers/ResponseMessageCatcher.py
+++ b/Test/Utils/TestHelpers/ResponseMessageCatcher.py
@@ -2,6 +2,7 @@ __version__ = "0.1"
 __author__ = "Eetu Asikainen"
 
 import queue
+from contextlib import contextmanager
 
 from discord import Message
 from discord.ext.commands import Bot
@@ -19,6 +20,15 @@ class ResponseMessageCatcher(ContextProvider):
 
     def set_administrator_status(self, is_guild_admin: bool):
         self._is_guild_admin = is_guild_admin
+
+    @contextmanager
+    def as_admin(self):
+        original_admin_status = self._is_guild_admin
+        try:
+            self._is_guild_admin = True
+            yield
+        finally:
+            self._is_guild_admin = original_admin_status
 
     async def get_context(self, client_super: Bot, message: Message):
         context = await client_super.get_context(message, cls=ResponseLoggerContext)


### PR DESCRIPTION
  - Added the command ';statistics [user] [game] to the RatingCommands.py Cog
  - Modified UserRatingConnection.py to attach existing UserScrimResult.py instances to new UserRating.py instances
  - Modified UserScrimResult.py to not be dependent on an existing UserRating.py instance
  - Added docstrings for commands in RatingCommands.py
  - Added tests for all changes and new functionalities
